### PR TITLE
chore: add eslintcache to gitignore (NON-ISSUE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # TypeScript build output
 dist/
+
+# eslint
+.eslintcache


### PR DESCRIPTION
## Overview
#26 에서 `. eslintcache` 가 깃 푸쉬되는 케이스가 발생
gitignore 에 추가해서 생성되더라도, 깃에 푸쉬 되지 않게

## Related issue

## Note
