### PR TITLE
chore(deps): move classnames to dependencies for production usage (NON-ISSUE)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "classnames": "2.5.1",
     "next": "15.3.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"
@@ -19,7 +20,6 @@
     "@types/node": "22.15.3",
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.3",
-    "classnames": "2.5.1",
     "sass": "1.89.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/client:
     dependencies:
+      classnames:
+        specifier: 2.5.1
+        version: 2.5.1
       next:
         specifier: 15.3.1
         version: 15.3.1(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.0)
@@ -81,9 +84,6 @@ importers:
       '@types/react-dom':
         specifier: 19.1.3
         version: 19.1.3(@types/react@19.1.2)
-      classnames:
-        specifier: 2.5.1
-        version: 2.5.1
       sass:
         specifier: 1.89.0
         version: 1.89.0


### PR DESCRIPTION
## Overview
classnames 은 애플리케이션 실행 시 실제로 사용되는 라이브러리이기 때문에,
dependencies 로 옮김

## Related issue

## Note
