### PR TITLE
refactor: split declaration and export in RootLayout and MockProvider (NON-ISSUE)

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -1,23 +1,21 @@
-import styles from './layout.module.scss';
-
+import type { ReactNode } from 'react';
 import MockProvider from '@/providers/mockProvider';
-
 import classNames from 'classnames/bind';
+
+import styles from './layout.module.scss';
 
 const cx = classNames.bind(styles);
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+const RootLayout = ({ children }: Readonly<{ children: ReactNode }>) => {
   return (
     <html lang="en">
       <body>
-        <div className={cx('container')}>
-          <MockProvider>{children}</MockProvider>
-        </div>
+        <MockProvider>
+          <div className={cx('container')}>{children}</div>
+        </MockProvider>
       </body>
     </html>
   );
-}
+};
+
+export default RootLayout;

--- a/apps/client/src/providers/mockProvider.tsx
+++ b/apps/client/src/providers/mockProvider.tsx
@@ -1,23 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
-export default function MswProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+const MockProvider = ({ children }: { children: ReactNode }) => {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      import('@packages/mock').then(({ worker }) => {
-        worker.start().then(() => setReady(true));
-      });
-    }
+    // TODO: Check if being used only for dev env.
+    (async () => {
+      const { worker } = await import('@packages/mock');
+      await worker.start();
+      setReady(true);
+    })();
   }, []);
 
-  if (!ready) return <div>Loading mocks...</div>;
+  return ready ? <>{children}</> : null;
+};
 
-  return <>{children}</>;
-}
+export default MockProvider;


### PR DESCRIPTION
## Overview
선언과 동시에 export 하면 코드가 너무 길어져서, 나누다

## Related issue

## Note
