### PR TITLE
chore: revert removed `tseslint.configs.stylistic` (NON-ISSUE)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
   },
   eslint.configs.recommended,
   ...tseslint.configs.strict,
+  ...tseslint.configs.stylistic,
   {
     languageOptions: {
       parser,


### PR DESCRIPTION
## Overview
#41 에서 지워진 `tseslint.configs.stylistic` 를 되돌리다

## Related issue

## Note
